### PR TITLE
Fix IP address detection bug when behind nginx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if os.environ.get('USER', '') == 'vagrant':
 setup(
 
     name='django-oscar-adyen',
-    version='0.1.1',
+    version='0.1.2',
     url='https://github.com/oscaro/django-oscar-adyen',
     author='Mathieu Richardoz',
     author_email='mr@babik.fr',


### PR DESCRIPTION
Kind of a trivial fix.
Nginx forwards the origin IP address in the <code>X-Forwarded-For</code> HTTP header, so we need to use this one when behind it.

@twidi, care to review? :smile: 
