### PR TITLE
Improve merchant reference readability

### DIFF
--- a/adyen/facade.py
+++ b/adyen/facade.py
@@ -74,10 +74,9 @@ class Facade():
         """
         Helper: extract data from the return value of `response.process`.
         """
-        merchant_ref = details.get(Constants.MERCHANT_REFERENCE, '')
-        customer_id, basket_id, order_number = merchant_ref.split(Constants.SEPARATOR)
-        psp_reference = details.get(Constants.PSP_REFERENCE, '')
+        order_number = details.get(Constants.MERCHANT_REFERENCE, '')
         payment_method = details.get(Constants.PAYMENT_METHOD, '')
+        psp_reference = details.get(Constants.PSP_REFERENCE, '')
 
         # The payment amount is transmitted in a different parameter whether
         # we are in the context of a PaymentRedirection (`merchantReturnData`)
@@ -91,8 +90,6 @@ class Facade():
 
         return {
             'amount': amount,
-            'basket_id': basket_id,
-            'customer_id': customer_id,
             'order_number': order_number,
             'payment_method': payment_method,
             'psp_reference': psp_reference,

--- a/adyen/scaffold.py
+++ b/adyen/scaffold.py
@@ -61,17 +61,11 @@ class Scaffold():
         ship_before_date = now + timezone.timedelta(days=30)
         ship_before_date_format = '%Y-%m-%d'
 
-        # We need to keep track of all these identifiers to make sure the
-        # application can find everything when coming back from Adyen.
-        merchant_reference = Constants.SEPARATOR.join((str(self.client_id),
-                                                       str(self.basket_id),
-                                                       str(self.order_number)))
-
         # Build common field specs
         try:
             field_specs = {
                 Constants.MERCHANT_ACCOUNT: settings.ADYEN_IDENTIFIER,
-                Constants.MERCHANT_REFERENCE: merchant_reference,
+                Constants.MERCHANT_REFERENCE: str(self.order_number),
                 Constants.SHOPPER_REFERENCE: self.client_id,
                 Constants.SHOPPER_EMAIL: self.client_email,
                 Constants.CURRENCY_CODE: self.currency_code,
@@ -87,6 +81,7 @@ class Scaffold():
                 Constants.MERCHANT_RETURN_DATA: self.amount,
 
             }
+
         except AttributeError:
             raise MissingFieldException
 

--- a/adyen/tests.py
+++ b/adyen/tests.py
@@ -30,9 +30,9 @@ TEST_FROZEN_TIME = '2014-07-31 17:00:00'
 EXPECTED_FIELDS_LIST = [
     {'type': 'hidden', 'name': 'currencyCode', 'value': 'EUR'},
     {'type': 'hidden', 'name': 'merchantAccount', 'value': TEST_IDENTIFIER},
-    {'type': 'hidden', 'name': 'merchantReference', 'value': '789:456:00000000123'},
+    {'type': 'hidden', 'name': 'merchantReference', 'value': '00000000123'},
     {'type': 'hidden', 'name': 'merchantReturnData', 'value': 123},
-    {'type': 'hidden', 'name': 'merchantSig', 'value': 'Oe5/RE9sryoqncgewUDM1+nzxHk='},
+    {'type': 'hidden', 'name': 'merchantSig', 'value': 'mCCvOn8nc4vdo5w2pUJ9u+mV7Gg='},
     {'type': 'hidden', 'name': 'paymentAmount', 'value': 123},
     {'type': 'hidden', 'name': 'resURL', 'value': TEST_RETURN_URL},
     {'type': 'hidden', 'name': 'sessionValidity', 'value': '2014-07-31T17:20:00Z'},

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if os.environ.get('USER', '') == 'vagrant':
 setup(
 
     name='django-oscar-adyen',
-    version='0.2.3',
+    version='0.2.4',
     url='https://github.com/oscaro/django-oscar-adyen',
     author='Mathieu Richardoz',
     author_email='mr@babik.fr',


### PR DESCRIPTION
At some point in the oshop development, we needed to keep a lot of information about the order, but we've found a more elegant way to deal with the underlying issue. We can therefore go back to a simpler scheme for the `merchant_reference` field.

The related issue is [here](https://github.com/oscaro/oshop/issues/1082). :smiley: 
