### PR TITLE
docs: Fix simple typo, mecanism -> mechanism

### DIFF
--- a/adyen/facade.py
+++ b/adyen/facade.py
@@ -50,7 +50,7 @@ class Facade:
 
     The ``Facade`` class exposes a set of public methods to be used by the
     plugin internally and by plugin users without having to deal with Adyen
-    internal mecanism (such as how to sign a request form or how to read a
+    internal mechanism (such as how to sign a request form or how to read a
     payment response).
 
     The first entry point is the payment form:


### PR DESCRIPTION
There is a small typo in adyen/facade.py.

Should read `mechanism` rather than `mecanism`.

