### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Changes
 - Handle merchantSig with SHA-256 algorithm
 - Improve test coverage and other minor changes
 
-This version is backwrd compatible with version 0.6.0.
+This version is backward compatible with version 0.6.0.
 
 Note that plugin users need to implement method ``get_signer_backend`` if they
 uses their own config class from the abstract config class.
@@ -112,7 +112,7 @@ uses their own config class from the abstract config class.
 .. warning::
 
    The implementation of the signature with SHA-256 algorithm has not been
-   tested in a real-life case. Plugin users may use it carefuly, and they are
+   tested in a real-life case. Plugin users may use it carefully, and they are
    invited to report any issues they may encounter.
 
 0.6.0 - released March 1st, 2016

--- a/adyen/signers.py
+++ b/adyen/signers.py
@@ -43,7 +43,7 @@ class AbstractSigner:
         appropriate signature field.
     * :meth:`compute_hash`: take a signature string and compute its hash value.
 
-    These methods are not implementd by the :class:`AbstractSigner`, therefore
+    These methods are not implemented by the :class:`AbstractSigner`, therefore
     subclasses **must** implement them.
     """
     def __init__(self, secret_key):
@@ -328,7 +328,7 @@ class HMACSha256(AbstractSigner):
         * We sort by key the valid keys (see :func:`is_valid_key`),
         * Both keys and values are escaped (see :func:`signature_escape`),
         * Then keys are joined by ``:``; same for the values,
-        * And these two strings are joined by anoter ``:``.
+        * And these two strings are joined by another ``:``.
 
         There is no such thing as a hard-coded defined order of keys: if a key
         is present, then it is used to sign the fields. This is much more

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -120,7 +120,7 @@ class DummyConfigClass(AbstractAdyenConfig):
 @override_settings(ADYEN_CONFIG_CLASS='tests.test_config.DummyConfigClass')
 class CustomConfigClassTestCase(TestCase):
     """
-    This test case checks that it's possible to replace the FromSettings confic class
+    This test case checks that it's possible to replace the FromSettings config class
     by one's own, and that it is used to fetch values as expected.
     """
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- adyen/signers.py
- tests/test_config.py

Fixes:
- Should read `implemented` rather than `implementd`.
- Should read `config` rather than `confic`.
- Should read `carefully` rather than `carefuly`.
- Should read `backward` rather than `backwrd`.
- Should read `another` rather than `anoter`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md